### PR TITLE
Blaze3D fix

### DIFF
--- a/game/26.2/src/main/java/cn/enaium/fabric/imgui/blaze3d/ImGuiImplBlaze3D.java
+++ b/game/26.2/src/main/java/cn/enaium/fabric/imgui/blaze3d/ImGuiImplBlaze3D.java
@@ -332,9 +332,8 @@ public class ImGuiImplBlaze3D {
                     continue;
                 }
 
-                // Vulkan framebuffer uses top-left origin (same as ImGui)
                 final int scissorX = (int) clipMinX;
-                final int scissorY = (int) clipMinY;
+                final int scissorY = (int) (fbHeight - clipMaxY);
                 final int scissorW = (int) (clipMaxX - clipMinX);
                 final int scissorH = (int) (clipMaxY - clipMinY);
 


### PR DESCRIPTION
Fixed an issue with Blaze3D backend only rendering text in the center third of the screen (something was wrong with the coordinate spaces)